### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk -U upgrade && \
 
 COPY . ./
 
+RUN shards init
 RUN shards update
 RUN shards build --release
 


### PR DESCRIPTION
Missing shard.yml. Please run 'shards init'
The command '/bin/sh -c shards update' returned a non-zero code: 1
ERROR: Service 'relay' failed to build : Build failed